### PR TITLE
Docker add joplin app

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,13 @@
 FROM python:3.6
-ENV PYTHONUNBUFFERED 1
+ENV PYTHONUNBUFFERED=1 \
+    JW_FULL_URL="http://127.0.0.1:8001/"
 WORKDIR  /app
 COPY requirements.txt /app/
 RUN curl -sL https://deb.nodesource.com/setup_13.x | bash - \
   && apt-get install nodejs \
   && NPM_CONFIG_PREFIX=/joplin-bin npm install --unsafe-perm -g joplin \
-  && ln -s /joplin-bin/bin/joplin /usr/bin/joplin
-  && pip install -r requirements.txt
+  && ln -s /joplin-bin/bin/joplin /usr/bin/joplin \
+  && pip install -r requirements.txt \
   && mkdir /data
 COPY joplin_web /app
 COPY docker-start.sh /app/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.6
 ENV PYTHONUNBUFFERED=1 \
     JW_FULL_URL="http://127.0.0.1:8001/"
-WORKDIR  /app
+WORKDIR /app
 COPY requirements.txt /app/
 RUN curl -sL https://deb.nodesource.com/setup_13.x | bash - \
   && apt-get install nodejs \
@@ -9,9 +9,7 @@ RUN curl -sL https://deb.nodesource.com/setup_13.x | bash - \
   && ln -s /joplin-bin/bin/joplin /usr/bin/joplin \
   && pip install -r requirements.txt \
   && mkdir /data
-COPY joplin_web /app
-COPY docker-start.sh /app/
-COPY .env /app/
+COPY joplin_web docker-start.sh .env /app/
 
 VOLUME /data
 EXPOSE 8001

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,17 @@
 FROM python:3.6
 ENV PYTHONUNBUFFERED 1
-RUN mkdir /app
 WORKDIR  /app
 COPY requirements.txt /app/
-RUN pip install -r requirements.txt
+RUN curl -sL https://deb.nodesource.com/setup_13.x | bash - \
+  && apt-get install nodejs \
+  && NPM_CONFIG_PREFIX=/joplin-bin npm install --unsafe-perm -g joplin \
+  && ln -s /joplin-bin/bin/joplin /usr/bin/joplin
+  && pip install -r requirements.txt
+  && mkdir /data
 COPY joplin_web /app
+COPY docker-start.sh /app/
+COPY .env /app/
 
+VOLUME /data
 EXPOSE 8001
-CMD ["python", "/app/app.py"]
+CMD ["/app/docker-start.sh"]

--- a/docker-start.sh
+++ b/docker-start.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+joplin --profile /data server start &
+python /app/app.py
+

--- a/docker-start.sh
+++ b/docker-start.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+set -eu
+echo "joplin-web available at ${JW_FULL_URL}"
+sed -i "s,http://0.0.0.0:8001/,${JW_FULL_URL},g" /app/templates/index.html
 joplin --profile /data server start &
 python /app/app.py
 

--- a/docker.md
+++ b/docker.md
@@ -4,7 +4,21 @@ if you prefer to run the project from docker follow that steps:
 
 ## before building 
 
-Do not forget to setup the parms in the `.env` file describes in the `settings` paragraph of the [README.md](README.md#settings)
+### set the environment
+`cp joplin_web/env.docker.sample .env`
+Copy the example env and do not forget to setup the parms in the `.env` file describes in the `settings` paragraph of the [README.md](README.md#settings). At least the joplin webclipper token needs to be set.
+
+### get the joplin config directory
+
+Configure your joplin app like you want it. Afterwards copy your joplin config directory to the directory where you want to mount the docker volume.
+
+`cp -r /home/foxmask/.config/joplin-desktop /data/`
+
+### define the URL to joplin web
+
+Think about the full URL where you want your joplin web app to be accessible. If you want to access it at the default URL `http://127.0.0.1:8001/` no separate definition is needed.
+
+If you want to change the URL, it is important that your URL ends with a slash.
 
 ## build the docker image by
 
@@ -14,21 +28,14 @@ docker build -t joplin-web-build .
 
 ## run the image
 ```
-docker run --network="host" -p 8001:8001 -v JOPLIN_RESOURCES:/path/to/.config/joplin-desktop/resources joplin-web-build
-
-docker run --network="host" -p 8001:8001 -v JOPLIN_RESOURCES:/home/foxmask/.config/joplin-desktop/resources joplin-web-build
-WARNING: Published ports are discarded when using host network mode
-Joplin Web - Starlette powered
-2019-08-22 17:43:39,659 - INFO - Started server process [1]
-2019-08-22 17:43:39,659 - INFO - Waiting for application startup.
-2019-08-22 17:43:39,661 - INFO - Uvicorn running on http://0.0.0.0:8001 (Press CTRL+C to quit)
-2019-08-22 17:43:49,374 - INFO - ('127.0.0.1', 50996) - "GET / HTTP/1.1" 200
-2019-08-22 17:43:49,458 - INFO - ('127.0.0.1', 50996) - "GET /static/css/chunk-vendors.css HTTP/1.1" 200
-2019-08-22 17:43:49,464 - INFO - ('127.0.0.1', 50998) - "GET /static/js/chunk-vendors.js HTTP/1.1" 200
-2019-08-22 17:43:49,465 - INFO - ('127.0.0.1', 51000) - "GET /static/js/app.js HTTP/1.1" 200
-2019-08-22 17:43:50,408 - INFO - ('127.0.0.1', 51026) - "GET /favicon.ico HTTP/1.1" 404
-2019-08-22 17:43:50,648 - INFO - ('127.0.0.1', 50996) - "GET /api/jw/tags/ HTTP/1.1" 200
-2019-08-22 17:43:51,230 - INFO - ('127.0.0.1', 51000) - "GET /api/jw/notes/ HTTP/1.1" 200
-2019-08-22 17:43:51,666 - INFO - ('127.0.0.1', 50998) - "GET /api/jw/folders/ HTTP/1.1" 200
-
+docker run -p 8001:8001 -v /data/joplin-desktop:/data -e JW_FULL_URL="http://192.168.0.3:8001/" joplin-web-build
+joplin-web available at http://192.168.0.3:8001/
+/
+Joplin Web Companion - Starlette powered
+INFO:     Started server process [8]
+INFO:     Waiting for application startup.
+INFO:     Application startup complete.
+INFO:     Uvicorn running on http://0.0.0.0:8001 (Press CTRL+C to quit)
+23:44:39
+INFO:     192.168.0.2:33462 - "GET / HTTP/1.1" 200 OK
 ```

--- a/docker.md
+++ b/docker.md
@@ -4,15 +4,16 @@ if you prefer to run the project from docker follow that steps:
 
 ## before building 
 
-### set the environment
-`cp joplin_web/env.docker.sample .env`
-Copy the example env and do not forget to setup the parms in the `.env` file describes in the `settings` paragraph of the [README.md](README.md#settings). At least the joplin webclipper token needs to be set.
-
 ### get the joplin config directory
 
-Configure your joplin app like you want it. Afterwards copy your joplin config directory to the directory where you want to mount the docker volume.
+Configure your joplin app like you want it. Connect to your joplin app with the webclipper and save the token for later. Afterwards copy your joplin config directory to the directory where you want to mount the docker volume.
 
 `cp -r /home/foxmask/.config/joplin-desktop /data/`
+
+### set the environment
+
+`cp joplin_web/env.docker.sample .env`
+Copy the example env and do not forget to setup the parms in the `.env` file describes in the `settings` paragraph of the [README.md](README.md#settings). At least the joplin webclipper token needs to be set.
 
 ### define the URL to joplin web
 

--- a/joplin_web/env.docker.sample
+++ b/joplin_web/env.docker.sample
@@ -1,0 +1,12 @@
+# running in debug mode or not ?
+JW_DEBUG = False
+# number of notes to get for each page
+JW_PAGINATOR = 20
+# listen port number
+JW_HTTP_PORT = 8001
+# the token ID you grab from the WebClipper config page with your Joplin
+JOPLIN_WEBCLIPPER_TOKEN = ''
+# path to get the joplin `resources` to be able to display them
+JOPLIN_RESOURCES = '/data/resources/'
+# BASE URL of the Joplin APP
+JW_BASE_URL = '/'


### PR DESCRIPTION
I started to include the joplin headless server into the docker container. This way i can easily run the joplin web application on a different host than my desktop pc.

To make it run, you need your desktop pc to create a joplin profile, which can be reused at the server. I have updated the docker documentation w.r.t. this.