### PR TITLE
vue/cli-plugin-babel bump needed to run on Node 14.2.0

### DIFF
--- a/joplin-vue/package.json
+++ b/joplin-vue/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@riophae/vue-treeselect": "^0.4.0",
-    "@vue/cli-plugin-babel": "^4.2.3",
+    "@vue/cli-plugin-babel": "^4.3.1",
     "axios": "^0.19.2",
     "bootstrap-vue": "^2.7.0",
     "core-js": "^3.6.4",


### PR DESCRIPTION
Without a version bump for `vue/cli-plugin-babel`, `cannot find module @babel/compat-data/corejs3-shipped-proposals` error will occur when running on Node 14.2.0.